### PR TITLE
fix: use shoelace-style area calculation algorithm

### DIFF
--- a/src/largestTriangleOneBucket.js
+++ b/src/largestTriangleOneBucket.js
@@ -41,10 +41,8 @@ export default function() {
             var thisPoint = xyData[i];
             var nextPoint = xyData[i + 1];
 
-            var base = (lastPoint[0] - nextPoint[0]) * (thisPoint[1] - lastPoint[1]);
-            var height = (lastPoint[0] - thisPoint[0]) * (nextPoint[1] - lastPoint[1]);
-
-            return Math.abs(0.5 * base * height);
+            return 0.5 * Math.abs((lastPoint[0] - nextPoint[0]) * (thisPoint[1] - lastPoint[1]) -
+                (lastPoint[0] - thisPoint[0]) * (nextPoint[1] - lastPoint[1]));
         });
 
         return pointAreas;

--- a/src/largestTriangleThreeBucket.js
+++ b/src/largestTriangleThreeBucket.js
@@ -32,12 +32,8 @@ export default function() {
 
             var xyData = thisBucket.map((item) => [x(item), y(item)]);
 
-            var areas = xyData.map((item) => {
-                var base = (lastSelectedX - nextAvgX) * (item[1] - lastSelectedY);
-                var height = (lastSelectedX - item[0]) * (nextAvgY - lastSelectedY);
-
-                return Math.abs(0.5 * base * height);
-            });
+            var areas = xyData.map((item) => 0.5 * Math.abs((lastSelectedX - nextAvgX) * (item[1] - lastSelectedY) -
+                    (lastSelectedX - item[0]) * (nextAvgY - lastSelectedY)));
 
             var highestIndex = areas.indexOf(max(areas));
             var highestXY = xyData[highestIndex];

--- a/test/largestTriangleOneBucketSpec.js
+++ b/test/largestTriangleOneBucketSpec.js
@@ -52,11 +52,11 @@ describe('largestTriangleOneBucket', function() {
 
         it('should return values that form the largest triangle in that bucket', function() {
             var sampledData = dataGenerator(data);
-            expect(sampledData[1].x).toEqual(3);
+            expect(sampledData[1].x).toEqual(2);
             expect(sampledData[2].x).toEqual(5);
-            expect(sampledData[3].x).toEqual(8);
+            expect(sampledData[3].x).toEqual(7);
             expect(sampledData[4].x).toEqual(12);
-            expect(sampledData[5].x).toEqual(14);
+            expect(sampledData[5].x).toEqual(13);
         });
 
     });
@@ -82,7 +82,7 @@ describe('largestTriangleOneBucket', function() {
             var sampledData = dataGenerator(data);
 
             expect(sampledData[0][0]).toEqual(0);
-            expect(sampledData[1][0]).toEqual(3);
+            expect(sampledData[1][0]).toEqual(2);
             expect(sampledData[2][0]).toEqual(4);
         });
     });

--- a/test/largestTriangleThreeBucketSpec.js
+++ b/test/largestTriangleThreeBucketSpec.js
@@ -52,11 +52,11 @@ describe('largestTriangleThreeBucket', function() {
 
         it('should return values that form the largest triangle in that bucket', function() {
             var sampledData = dataGenerator(data);
-            expect(sampledData[1].x).toEqual(1);
+            expect(sampledData[1].x).toEqual(2);
             expect(sampledData[2].x).toEqual(4);
             expect(sampledData[3].x).toEqual(7);
-            expect(sampledData[4].x).toEqual(11);
-            expect(sampledData[5].x).toEqual(15);
+            expect(sampledData[4].x).toEqual(12);
+            expect(sampledData[5].x).toEqual(13);
         });
 
     });
@@ -80,7 +80,7 @@ describe('largestTriangleThreeBucket', function() {
             var sampledData = dataGenerator(data);
 
             expect(sampledData[0][0]).toEqual(0);
-            expect(sampledData[1][0]).toEqual(1);
+            expect(sampledData[1][0]).toEqual(2);
             expect(sampledData[2][0]).toEqual(4);
         });
     });


### PR DESCRIPTION
Resolves #44 

I'm not sure how this one slipped through, looking at the unit tests the data obviously points to certain points being better.

eg:

```
                { x: 0, y: 6 }, // Bucket 1
                { x: 1, y: 8 }, // Bucket 2
                { x: 2, y: 1 },
                { x: 3, y: 9 },
                { x: 4, y: 12 }, // Bucket 3
                { x: 5, y: 3 },
                { x: 6, y: 9 },
```

In one-bucket this checks for local maxima, so comparing the adjacent points does yield that x=2 would be the correct point, but it was choosing `x=3`.

In three-bucket, it checks for the average of the points (`5, 8`), which again looking at the data, x=2 would be the larger triangle, not `x=1`.

Similar applies to the array data example below.

```
                [0, 6], // Bucket 1
                [1, 8], // Bucket 2
                [2, 1],
                [3, 9],
                [4, 12] // Bucket 3
```